### PR TITLE
Add jberet-schedule-timer to samples dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,10 @@
             <groupId>org.jberet</groupId>
             <artifactId>jberet-schedule-executor</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jberet</groupId>
+            <artifactId>jberet-schedule-timer</artifactId>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>


### PR DESCRIPTION
Add the jberet-schedule-timer scheduler to samples dependencies.

This allows the feature to be available in the resetAPI example to test jberet-ui.