### PR TITLE
JBERET-583 - Update `maven-wildfly-plugin` to `4.0.0.Final`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <properties>
         <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>2.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
-        <version.maven.wildfly.plugin>3.0.1.Final</version.maven.wildfly.plugin>
+        <version.maven.wildfly.plugin>4.0.0.Final</version.maven.wildfly.plugin>
         <version.org.jboss.resteasy>4.7.4.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.resteasy-jackson-provider>4.0.0.Beta5</version.org.jboss.resteasy.resteasy-jackson-provider>
         <version.org.jberet.rest>1.4.1.Final</version.org.jberet.rest>


### PR DESCRIPTION
The current used version of `wildfly-maven-plugin` has this problem:

<img width="1940" alt="image" src="https://user-images.githubusercontent.com/201907/201386365-dd77fccd-14f0-4d45-b9f3-dcc3e447c01d.png">
