### PR TITLE
JBERET-585 - Set `wildfly` version to `26.0.0.Final`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <properties>
         <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>2.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
         <version.maven.wildfly.plugin>4.0.0.Final</version.maven.wildfly.plugin>
+        <wildfly.version>26.0.0.Final</wildfly.version>
         <version.org.jboss.resteasy>4.7.4.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.resteasy-jackson-provider>4.0.0.Beta5</version.org.jboss.resteasy.resteasy-jackson-provider>
         <version.org.jberet.rest>1.4.1.Final</version.org.jberet.rest>
@@ -210,6 +211,7 @@
                     <groupId>org.wildfly.plugins</groupId>
                     <artifactId>wildfly-maven-plugin</artifactId>
                     <version>${version.maven.wildfly.plugin}</version>
+
                     <executions>
                         <execution>
                             <id>wildfly-deploy</id>


### PR DESCRIPTION
Currently the `Wildfly 27` is not supported yet because of `jakarata.*` upgrades.